### PR TITLE
FAT/exFAT: Fix wrong size detection for files > 4GB

### DIFF
--- a/grub-core/fs/fat.c
+++ b/grub-core/fs/fat.c
@@ -183,7 +183,11 @@ struct grub_fat_data
   grub_uint32_t num_clusters;
 
   grub_uint8_t attr;
-  grub_ssize_t file_size;
+#ifndef MODE_EXFAT
+  grub_uint32_t file_size;
+#else
+  grub_uint64_t file_size;
+#endif
   grub_uint32_t file_cluster;
   grub_uint32_t cur_cluster_num;
   grub_uint32_t cur_cluster;


### PR DESCRIPTION
https://phabricator.endlessm.com/T13010