### PR TITLE
efi/chainloader: don't print device path to console

### DIFF
--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -169,7 +169,9 @@ make_file_path (grub_efi_device_path_t *dp, const char *filename)
   /* Fill the file path for the directory.  */
   d = (grub_efi_device_path_t *) ((char *) file_path
 				  + ((char *) d - (char *) dp));
+#ifdef DEBUG_NAMES
   grub_efi_print_device_path (d);
+#endif
   copy_file_path ((grub_efi_file_path_device_path_t *) d,
 		  dir_start, dir_end - dir_start);
 
@@ -257,8 +259,10 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
   if (! file_path)
     goto fail;
 
+#ifdef DEBUG_NAMES
   grub_printf ("file path: ");
   grub_efi_print_device_path (file_path);
+#endif
 
   size = grub_file_size (file);
   if (!size)


### PR DESCRIPTION
At present, you get output like this printed to the console when you
chainload another EFI binary (such as the Windows bootloader):

   /EndEntire
   file path: /ACPI(...)/.../.../File(BOOTMGFW.EFI)/EndEntire

This must have been for debugging at some point, but is confusing to end users. There
are similar calls to grub_efi_print_device_path() in efi/efidisk.c
guarded by DEBUG_NAMES, so let's guard these the same way.

https://phabricator.endlessm.com/T13258