### PR TITLE
Make grub-efi-amd64-image conflict with signed version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -720,3 +720,5 @@ Architecture: i386 kopensolaris-i386 any-amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: foreign
 Description: GRUB EFI image
+Conflicts: grub-efi-amd64-image-signed
+Replaces: grub-efi-amd64-image-signed


### PR DESCRIPTION
The grub-efi-amd64-image-signed package will provide grubx64.efi signed
by the Endless secure boot key. The file lives at the same spot, so the
packages must conflict with each other.

https://phabricator.endlessm.com/T12944