### PR TITLE
efi/chainloader: add debug output on error

### DIFF
--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -338,7 +338,19 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
       if (status == GRUB_EFI_OUT_OF_RESOURCES)
 	grub_error (GRUB_ERR_OUT_OF_MEMORY, "out of resources");
       else
-	grub_error (GRUB_ERR_BAD_OS, "cannot load image");
+	{
+	  const char *kind = "warning";
+	  grub_efi_status_t unwrapped_status = status;
+
+	  if (GRUB_EFI_IS_ERROR_CODE (status))
+	    {
+	      kind = "error";
+	      unwrapped_status = GRUB_EFI_UNWRAP_ERROR_CODE (status);
+	    }
+
+	  grub_error (GRUB_ERR_BAD_OS, "cannot load image: %s: %" PRIdGRUB_EFI_STATUS,
+		      kind, unwrapped_status);
+	}
 
       goto fail;
     }

--- a/grub-core/loader/efi/chainloader.c
+++ b/grub-core/loader/efi/chainloader.c
@@ -352,6 +352,18 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
 		      kind, unwrapped_status);
 	}
 
+      grub_printf ("Please take a photograph of this message, and post it on\n\n"
+		   "http://community.endlessm.com/\n\n");
+      grub_printf ("grub_efi_image_handle=%p\n"
+                   "boot_image=%p\n"
+                   "size=%" PRIdGRUB_SSIZE "\n",
+                   grub_efi_image_handle,
+                   boot_image,
+                   size);
+
+      grub_printf ("file path: ");
+      grub_efi_print_device_path (file_path);
+
       goto fail;
     }
 

--- a/include/grub/efi/api.h
+++ b/include/grub/efi/api.h
@@ -478,9 +478,14 @@ typedef grub_uint8_t grub_efi_char8_t;
 typedef grub_uint16_t grub_efi_char16_t;
 
 typedef grub_efi_intn_t grub_efi_status_t;
+#define PRIdGRUB_EFI_STATUS PRIdGRUB_SSIZE
 
 #define GRUB_EFI_ERROR_CODE(value)	\
   ((((grub_efi_status_t) 1) << (sizeof (grub_efi_status_t) * 8 - 1)) | (value))
+#define GRUB_EFI_IS_ERROR_CODE(value)	\
+  ((((grub_efi_status_t) 1) << (sizeof (grub_efi_status_t) * 8 - 1)) & (value))
+#define GRUB_EFI_UNWRAP_ERROR_CODE(value) \
+  (~(((grub_efi_status_t) 1) << (sizeof (grub_efi_status_t) * 8 - 1)) & (value))
 
 #define GRUB_EFI_WARNING_CODE(value)	(value)
 


### PR DESCRIPTION
Here's the output when I try to chainload 1MiB of `/dev/random` from the UEFI shell in VirtualBox:

![screenshot from 2016-11-16 17-18-56](https://cloud.githubusercontent.com/assets/86760/20357928/d111317c-ac21-11e6-95d0-77b5d20f6247.png)

And in GRUB with this patch (minus the URL bit):

![screenshot from 2016-11-16 17-12-41](https://cloud.githubusercontent.com/assets/86760/20357929/d12a8b18-ac21-11e6-89cd-fdd35162d2eb.png)

Error `3` is `UNSUPPORTED`, so this seems to work…

https://phabricator.endlessm.com/T14019