### PR TITLE
search: add optional --quiet parameter

### DIFF
--- a/grub-core/commands/search.c
+++ b/grub-core/commands/search.c
@@ -324,7 +324,7 @@ try (struct search_ctx *ctx)
 }
 
 void
-FUNC_NAME (const char *key, const char *var, int no_floppy,
+FUNC_NAME (const char *key, const char *var, int no_floppy, int quiet,
 	   char **hints, unsigned nhints)
 {
   struct search_ctx ctx = {
@@ -355,7 +355,7 @@ FUNC_NAME (const char *key, const char *var, int no_floppy,
   else
     try (&ctx);
 
-  if (grub_errno == GRUB_ERR_NONE && ctx.count == 0)
+  if (!quiet && grub_errno == GRUB_ERR_NONE && ctx.count == 0)
     grub_error (GRUB_ERR_FILE_NOT_FOUND, "no such device: %s", key);
 }
 
@@ -366,7 +366,7 @@ grub_cmd_do_search (grub_command_t cmd __attribute__ ((unused)), int argc,
   if (argc == 0)
     return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("one argument expected"));
 
-  FUNC_NAME (args[0], argc == 1 ? 0 : args[1], 0, (args + 2),
+  FUNC_NAME (args[0], argc == 1 ? 0 : args[1], 0, 0, (args + 2),
 	     argc > 2 ? argc - 2 : 0);
 
   return grub_errno;

--- a/grub-core/commands/search_wrap.c
+++ b/grub-core/commands/search_wrap.c
@@ -42,6 +42,7 @@ static const struct grub_arg_option options[] =
      N_("Set a variable to the first device found."), N_("VARNAME"),
      ARG_TYPE_STRING},
     {"no-floppy",	'n', 0, N_("Do not probe any floppy drive."), 0, 0},
+    {"quiet",		'q', 0, N_("Don't print error if no match."), 0, 0},
     {"hint",	        'h', GRUB_ARG_OPTION_REPEATABLE,
      N_("First try the device HINT. If HINT ends in comma, "
 	"also try subpartitions"), N_("HINT"), ARG_TYPE_STRING},
@@ -76,6 +77,7 @@ enum options
     SEARCH_FS_TYPE,
     SEARCH_SET,
     SEARCH_NO_FLOPPY,
+    SEARCH_QUIET,
     SEARCH_HINT,
     SEARCH_HINT_IEEE1275,
     SEARCH_HINT_BIOS,
@@ -185,16 +187,16 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
 
   if (state[SEARCH_LABEL].set)
     grub_search_label (id, var, state[SEARCH_NO_FLOPPY].set, 
-		       hints, nhints);
+		       state[SEARCH_QUIET].set, hints, nhints);
   else if (state[SEARCH_FS_UUID].set)
     grub_search_fs_uuid (id, var, state[SEARCH_NO_FLOPPY].set,
-			 hints, nhints);
+			 state[SEARCH_QUIET].set, hints, nhints);
   else if (state[SEARCH_FS_TYPE].set)
     grub_search_fs_type (id, var, state[SEARCH_NO_FLOPPY].set,
-			 hints, nhints);
+			 state[SEARCH_QUIET].set, hints, nhints);
   else if (state[SEARCH_FILE].set)
     grub_search_fs_file (id, var, state[SEARCH_NO_FLOPPY].set, 
-			 hints, nhints);
+			 state[SEARCH_QUIET].set, hints, nhints);
   else
     grub_error (GRUB_ERR_INVALID_COMMAND, "unspecified search type");
 

--- a/include/grub/search.h
+++ b/include/grub/search.h
@@ -20,12 +20,12 @@
 #define GRUB_SEARCH_HEADER 1
 
 void grub_search_fs_file (const char *key, const char *var, int no_floppy,
-			  char **hints, unsigned nhints);
+			  int quiet, char **hints, unsigned nhints);
 void grub_search_fs_uuid (const char *key, const char *var, int no_floppy,
-			  char **hints, unsigned nhints);
+			  int quiet, char **hints, unsigned nhints);
 void grub_search_fs_type (const char *key, const char *var, int no_floppy,
-			  char **hints, unsigned nhints);
+			  int quiet, char **hints, unsigned nhints);
 void grub_search_label (const char *key, const char *var, int no_floppy,
-			char **hints, unsigned nhints);
+			int quiet, char **hints, unsigned nhints);
 
 #endif


### PR DESCRIPTION
Currently when you search for a file, if no result is found it prints
an error message.

That's not ideal when the file is optional, so add a --quiet arg
to silence this.

https://phabricator.endlessm.com/T14231