### PR TITLE
UEFI config: make search quiet

### DIFF
--- a/debian/endless-uefi-grub.cfg
+++ b/debian/endless-uefi-grub.cfg
@@ -1,4 +1,4 @@
-search.file /endless/endless.img eoslive $bootdev,
+search --file --quiet /endless/endless.img eoslive $bootdev,
 
 # Can't limit search.file to one device; so fake it:
 if [ ( "$eoslive" -a "$eoslive" ">=" "$bootdev," -a "$eoslive" "<" "$bootdev-" ) ]; then


### PR DESCRIPTION
Otherwise this prints out an error message when the file can't be
found (e.g. on single-OS setups)

https://phabricator.endlessm.com/T14231