### PR TITLE
Fix search --file syntax for image-boots

### DIFF
--- a/debian/build-sa-efi-images
+++ b/debian/build-sa-efi-images
@@ -1,8 +1,9 @@
 #! /bin/sh
 set -e
 
-if [ $# -lt 5 ]; then
-	echo "usage: $0 GRUB-MKSTANDALONE GRUB-CORE OUTPUT-DIRECTORY PLATFORM EFI-NAME"
+if [ $# -lt 6 ]; then
+	echo "usage: $0 GRUB-MKSTANDALONE GRUB-CORE OUTPUT-DIRECTORY PLATFORM EFI-NAME CONF-NAME"
+	exit 1
 fi
 
 grub_mkstandalone="$1"

--- a/debian/endless-uefi-grub.cfg
+++ b/debian/endless-uefi-grub.cfg
@@ -1,4 +1,4 @@
-search --file --quiet /endless/endless.img eoslive $bootdev,
+search --set=eoslive --file --hint $bootdev, --quiet /endless/endless.img
 
 # Can't limit search.file to one device; so fake it:
 if [ ( "$eoslive" -a "$eoslive" ">=" "$bootdev," -a "$eoslive" "<" "$bootdev-" ) ]; then


### PR DESCRIPTION
This is a regression in 559fa10 which I missed in review. Previously we
used `search.file`, which takes purely positional parameters. To support
--quiet we switched to `search --file`, a wrapper command which takes named
parameters (except for a single positional parameter -- in this case, the
filename to search for).

As a result, rather than initializing $eoslive, the partition ID was
printed to the console, and then we fell through to the full-installation
path.

I have reordered the parameters here to match the later call to `search
... --fs-type`. The remaining difference is the trailing comma on the hint,
which is significant.

https://phabricator.endlessm.com/T14231