### PR TITLE
linux: allow module to register when booting securely

### DIFF
--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -1187,9 +1187,6 @@ static grub_command_t cmd_linux, cmd_initrd;
 
 GRUB_MOD_INIT(linux)
 {
-  if (grub_efi_secure_boot())
-    return;
-
   cmd_linux = grub_register_command ("linux", grub_cmd_linux,
 				     0, N_("Load Linux."));
   cmd_initrd = grub_register_command ("initrd", grub_cmd_initrd,
@@ -1199,9 +1196,6 @@ GRUB_MOD_INIT(linux)
 
 GRUB_MOD_FINI(linux)
 {
-  if (grub_efi_secure_boot())
-    return;
-
   grub_unregister_command (cmd_linux);
   grub_unregister_command (cmd_initrd);
 }


### PR DESCRIPTION
Fixes 7bdcf6d4b16a61bfa8a3b5e2a433956abcad09aa

For our converted systems we use the "linux" command and expect
it to dynamically redirect to linuxefi/initrdefi for secure boot
systems. But for this to work we have to allow the module to load.

https://phabricator.endlessm.com/T14258