### PR TITLE
Disable cbfs module

### DIFF
--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -91,7 +91,6 @@ library = {
   common = grub-core/fs/afs.c;
   common = grub-core/fs/bfs.c;
   common = grub-core/fs/btrfs.c;
-  common = grub-core/fs/cbfs.c;
   common = grub-core/fs/cpio.c;
   common = grub-core/fs/cpio_be.c;
   common = grub-core/fs/odc.c;

--- a/grub-core/Makefile.core.def
+++ b/grub-core/Makefile.core.def
@@ -1272,11 +1272,6 @@ module = {
 };
 
 module = {
-  name = cbfs;
-  common = fs/cbfs.c;
-};
-
-module = {
   name = cpio;
   common = fs/cpio.c;
 };


### PR DESCRIPTION
This is not of interest to Endless, and it is causing us some problems.

When searching for endless.img during boot, this fs module is reading
the last sector of available block devices.

We have now seen 2 cases where buggy UEFI firmware provides the
bad last sector number, causing very long delays during boot while
those sectors are attempted to be read.

Avoid this problem by disabling cbfs.

https://phabricator.endlessm.com/T14713