### PR TITLE
Build bootia32.efi for UEFI-32 unsecure boot

### DIFF
--- a/debian/build-sa-efi-images
+++ b/debian/build-sa-efi-images
@@ -48,7 +48,7 @@ modules="$modules search search_fs_uuid search_fs_file search_label search_fs_ty
 modules="$modules sleep test time true verify video hexdump"
 
 ( cd "$workdir/memdisk" && "$grub_mkstandalone" --modules="$modules" \
-	-d "$grub_core" -O "$platform" -o "$outdir/grub$efi_name.efi" \
+	-d "$grub_core" -O "$platform" -o "$outdir/$efi_name.efi" \
 	$(find -type f))
 
 exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -470,12 +470,16 @@ override_dh_gencontrol:
 TARNAME := grub2_$(deb_version)_$(DEB_HOST_ARCH).tar.gz
 
 override_dh_builddeb:
-	mkdir -p debian/grub-efi-amd64-image/boot/efi/EFI/BOOT/
 	debian/build-sa-efi-images \
 		obj/grub-$(COMMON_PLATFORM)/grub-mkstandalone \
 		obj/grub-efi-amd64/grub-core \
 		debian/grub-efi-amd64-image/boot/efi/EFI/endless/ \
-		x86_64-efi x64 debian/endless-uefi-grub.cfg
+		x86_64-efi grubx64 debian/endless-uefi-grub.cfg
+	debian/build-sa-efi-images \
+		obj/grub-$(COMMON_PLATFORM)/grub-mkstandalone \
+		obj/grub-efi-ia32/grub-core \
+		debian/grub-efi-amd64-image/boot/efi/EFI/BOOT/ \
+		i386-efi bootia32 debian/endless-uefi-grub.cfg
 	dh_builddeb -- -Zxz
 ifneq (,$(SB_PACKAGE))
 	debian/build-efi-images \


### PR DESCRIPTION
Remove the redundant mkdir from the rules file
(build-sa-efi-images does this).

Adjust script invocation to allow us to output a file named bootia32.efi
in the standard boot directory.

This adds support for booting UEFI-32 in unsecure mode.

https://phabricator.endlessm.com/T13970