### PR TITLE
blscfg: don't use linuxefi under UEFI-32

### DIFF
--- a/grub-core/commands/blscfg.c
+++ b/grub-core/commands/blscfg.c
@@ -33,7 +33,7 @@
 
 GRUB_MOD_LICENSE ("GPLv3+");
 
-#ifdef GRUB_MACHINE_EFI
+#if defined(GRUB_MACHINE_EFI) && !defined(__i386__)
 #define GRUB_LINUX_CMD "linuxefi"
 #define GRUB_INITRD_CMD "initrdefi"
 #else


### PR DESCRIPTION
Even with kernels with EFI mixed mode enabled, our only UEFI-32
platform (Weibu F3C) is not able to boot kernels using linuxefi,
the system totally hangs before we get any kind of output.

Ubuntu also uses "linux" on this setup. Lets do the same until
we have more information about the failure to boot using EFI mixed
mode.

https://phabricator.endlessm.com/T13970