### PR TITLE
conf: avoid "file '/grubenv' not found" under eosldr

### DIFF
--- a/debian/conf/grub.cfg
+++ b/debian/conf/grub.cfg
@@ -3,9 +3,9 @@ function load_video {
 }
 
 function savedefault {
-    if test ( ! "$is_live" -a "$eosimage" ) ; then
+    if test "$grubenv" ; then
         saved_entry="${chosen}"
-        save_env -f $grubroot/grubenv saved_entry
+        save_env -f $grubenv saved_entry
     fi
 }
 
@@ -49,6 +49,7 @@ if test "$eosimage" ; then
         set is_live=true
     else
         set grubroot=($eosimage)/endless/grub
+        set grubenv=$grubroot/grubenv
 
         # test for Windows hibernation
         if test -f ($eosimage)/hiberfil.sys ; then
@@ -59,8 +60,8 @@ if test "$eosimage" ; then
         fi
 
         # remember latest selection
-        if test -f $grubroot/grubenv ; then
-            load_env -f $grubroot/grubenv
+        if test -f $grubenv ; then
+            load_env -f $grubenv
         fi
 
         if test "$saved_entry" ; then


### PR DESCRIPTION
When loaded via eosldr, the following error is shown

    Error: file `/grubenv' not found.

    Press any key to continue...

(After pressing the Any Key, the system boot correctly, without a menu
from GRUB.) This is because $grubroot is only defined when eosldr is not
found.

We only want 'savedefault' to have any effect when we've shown a menu.
The correct conditions for that are ! $is_live && $eosimage && ! -f
($eosimage)/eosldr -- exactly the conditions under which $grubroot is
defined. So, make this explicit: define a variable for the path to the
'grubenv' file, and use this as the sole condition for savedefault to
have any effect.

https://phabricator.endlessm.com/T14545