### PR TITLE
Fix mashing ESC on EFI systems while image-booting

### DIFF
--- a/debian/conf/grub_embedded_image.cfg
+++ b/debian/conf/grub_embedded_image.cfg
@@ -2,9 +2,9 @@
 
 search --set=eosimage --file --hint $bootdev, --quiet /endless/grub/grub.cfg
 if regexp "^$bootdev(|,.+)\$" "$eosimage"; then
-	set prefix=($eosimage)/endless/grub
-	export eosimage
-	configfile $prefix/grub.cfg
+    set prefix=($eosimage)/endless/grub
+    export eosimage
+    configfile $prefix/grub.cfg
 fi
 
 unset eosimage

--- a/debian/conf/grub_embedded_image.cfg
+++ b/debian/conf/grub_embedded_image.cfg
@@ -9,4 +9,4 @@ else
     search --set=root --label ostree --hint $bootdev,
     set prefix=($root)/boot/grub
 fi
-configfile $prefix/grub.cfg
+normal $prefix/grub.cfg

--- a/debian/conf/grub_embedded_image.cfg
+++ b/debian/conf/grub_embedded_image.cfg
@@ -4,10 +4,9 @@ search --set=eosimage --file --hint $bootdev, --quiet /endless/grub/grub.cfg
 if regexp "^$bootdev(|,.+)\$" "$eosimage"; then
     set prefix=($eosimage)/endless/grub
     export eosimage
-    configfile $prefix/grub.cfg
+else
+    unset eosimage
+    search --set=root --label ostree --hint $bootdev,
+    set prefix=($root)/boot/grub
 fi
-
-unset eosimage
-search --set=root --label ostree --hint $bootdev,
-set prefix=($root)/boot/grub
 configfile $prefix/grub.cfg


### PR DESCRIPTION
I have not tested this fix yet with the BIOS standalone image, but surely it should work the same? Famous last words.

https://phabricator.endlessm.com/T18758