### PR TITLE
Include cbfs.c in dist tarball

### DIFF
--- a/Makefile.util.def
+++ b/Makefile.util.def
@@ -91,6 +91,7 @@ library = {
   common = grub-core/fs/afs.c;
   common = grub-core/fs/bfs.c;
   common = grub-core/fs/btrfs.c;
+  extra_dist = grub-core/fs/cbfs.c;
   common = grub-core/fs/cpio.c;
   common = grub-core/fs/cpio_be.c;
   common = grub-core/fs/odc.c;


### PR DESCRIPTION
We do not want to build this module, see 24f83f7 for rationale.

At autogen.sh time, po/POTFILES.in is generated by listing source files
in the source tree. When run from a git checkout, this includes cbfs.c.
po/POTFILES.in is included in the source tarball generated by make dist,
but cbfs.c was previously not included. This led to `make distcheck`
failing when it runs `make dist` on the re-unpacked tarball.

I cannot explain why this did not fail before. Could it be that an
Automake upgrade has changed the behaviour of `make distcheck`?

Of course, cbfs.c doesn't have any strings marked for translation
anyway...

https://phabricator.endlessm.com/T18922