### PR TITLE
Use C:\...\grubenv; check hiberfil on eosldr; use file not hexdump

### DIFF
--- a/debian/build-sa-efi-images
+++ b/debian/build-sa-efi-images
@@ -45,7 +45,7 @@ modules="$modules halt hfsplus iso9660 jpeg keystatus loadenv loopback linux lin
 modules="$modules lsefi lsefimmap lsefisystab lssal memdisk minicmd normal ntfs"
 modules="$modules part_apple part_msdos part_gpt password_pbkdf2 png probe read reboot regexp"
 modules="$modules search search_fs_uuid search_fs_file search_label search_fs_type"
-modules="$modules sleep test time true verify video hexdump squash4 ls"
+modules="$modules sleep test time true verify video file squash4 ls"
 
 ( cd "$workdir/memdisk" && "$grub_mkstandalone" --modules="$modules" \
 	-d "$grub_core" -O "$platform" -o "$outdir/$efi_name.efi" \

--- a/debian/conf/grub.cfg
+++ b/debian/conf/grub.cfg
@@ -49,8 +49,7 @@ if test "$eosimage" ; then
 
     # test for Windows hibernation
     if test -f ($eosimage)/hiberfil.sys ; then
-        hexdump -n 4 ($eosimage)/hiberfil.sys hibr_var
-        if test ( "$hibr_var" == "HIBR" -o "$hibr_var" == "hibr" ) ; then
+        if file --is-hibernated-hiberfil ($eosimage)/hiberfil.sys ; then
             set hibernation=true
         fi
     fi

--- a/debian/conf/grub.cfg
+++ b/debian/conf/grub.cfg
@@ -8,7 +8,7 @@ function savedefault {
         save_env -f $grubenv saved_entry
     fi
 
-    if ! test ( "$is_live" -o "$booting_windows" ) ; then
+    if ! test "$eosimage" ; then
         recordfail=1
         save_env -f $grubenv recordfail
     fi
@@ -29,6 +29,7 @@ if [ "x${timeout}" != "x-1" ]; then
 fi
 
 if test "$eosimage" ; then
+    set grubenv=($eosimage)/endless/grub/grubenv
 
     # ISO
     if test -f ($eosimage)/endless/endless.squash ; then
@@ -123,9 +124,9 @@ if test "$eosimage" ; then
     fi
 else
     probe -u $root --set=rootuuid
+    set grubenv=($root)/boot/grub/grubenv
 fi
 
-set grubenv=($root)/boot/grub/grubenv
 export grubenv
 
 if test -f $grubenv ; then

--- a/debian/conf/grub.cfg
+++ b/debian/conf/grub.cfg
@@ -47,9 +47,23 @@ if test "$eosimage" ; then
     probe -u $eosimage --set=image_dev_uuid
     set kparams="endless.image.device=UUID=$image_dev_uuid endless.image.path=$image_path nohibernate"
 
+    # test for Windows hibernation
+    if test -f ($eosimage)/hiberfil.sys ; then
+        hexdump -n 4 ($eosimage)/hiberfil.sys hibr_var
+        if test ( "$hibr_var" == "HIBR" -o "$hibr_var" == "hibr" ) ; then
+            set hibernation=true
+        fi
+    fi
+
     if test -f ($eosimage)/eosldr ; then
-        # Do nothing
-        true
+        # If we can't boot Endless OS, provide a dummy Windows entry which
+        # reboots to the Windows boot menu.
+        if test "$hibernation" ; then
+            set found_windows=true
+            menuentry "Microsoft Windows" {
+                reboot
+            }
+        fi
     elif test -f ($eosimage)/endless/live ; then
         set kparams="$kparams endless.live_boot"
         set is_live=true
@@ -57,14 +71,6 @@ if test "$eosimage" ; then
     else
         set should_savedefault=true
         export should_savedefault
-
-        # test for Windows hibernation
-        if test -f ($eosimage)/hiberfil.sys ; then
-            hexdump -n 4 ($eosimage)/hiberfil.sys hibr_var
-            if test ( "$hibr_var" == "HIBR" -o "$hibr_var" == "hibr" ) ; then
-                set hibernation=true
-            fi
-        fi
 
         # search for other OSes
         insmod regexp


### PR DESCRIPTION
These patches address three related issues on dual-boot systems, in descending order of priority:

* https://phabricator.endlessm.com/T18551 - use `C:\endless\grub\grubenv` (fixes a regression in 3.3.6 which affects all new dual-boot installations)
* https://phabricator.endlessm.com/T20513 - add `hiberfil.sys` check on eosldr path (fixes a regression in 3.2.0, affects some but not all new dual-boot installations on BIOS machines)
* https://phabricator.endlessm.com/T20509 - use `file --is-hibernated-hiberfil` (no user-visible change, but will allow us to drop a downstream GRUB patch)

Merging all three together will reduce the number of times we have to test {dual boot, standalone} × {hibernated, not hibernated} × {BIOS, EFI}, but we could take any prefix