### PR TITLE
boot: suppress "GRUB" when booting ISOs on BIOS

### DIFF
--- a/grub-core/boot/i386/pc/boot.S
+++ b/grub-core/boot/i386/pc/boot.S
@@ -19,7 +19,7 @@
 
 #include <grub/symbol.h>
 #include <grub/machine/boot.h>
-#if defined(QUIET_BOOT) && !defined(HYBRID_BOOT)
+#if defined(QUIET_BOOT)
 #include <grub/machine/memory.h>
 #endif
 
@@ -252,7 +252,7 @@ real_start:
 	/* save drive reference first thing! */
 	pushw	%dx
 
-#if defined(QUIET_BOOT) && !defined(HYBRID_BOOT)
+#if defined(QUIET_BOOT)
 	/* is either shift key held down? */
 	movw	$(GRUB_MEMORY_MACHINE_BIOS_DATA_AREA_ADDR + 0x17), %bx
 	testb	$3, (%bx)


### PR DESCRIPTION
QUIET_BOOT is introduced by 85d4af5 which we inherited from Ubuntu.
HYBRID_BOOT is defined when building boot_hybrid.img, which is used to
boot an ISO written to non-optical media on BIOS systems.

For whatever reason, Colin's patch explicitly excluded boot_hybrid.img
from the silent treatment – perhaps because silent boot is less
important when booting from live media, given you've already had to
interact with the BIOS.

https://phabricator.endlessm.com/T15531