### PR TITLE
Avoid saving specific Endless versions as default boot option

### DIFF
--- a/grub-core/commands/blscfg.c
+++ b/grub-core/commands/blscfg.c
@@ -163,8 +163,7 @@ static int parse_entry (
   entry->title = grub_legacy_escape(boot_title, grub_strlen (boot_title));
 
   /* Generate the entry */
-  entry->src = grub_xasprintf ("savedefault\n"
-                               "load_video\n"
+  entry->src = grub_xasprintf ("load_video\n"
                                "set gfx_payload=keep\n"
                                "insmod gzio\n"
                                GRUB_LINUX_CMD " %s%s%s%s%s%s%s%s\n"
@@ -197,6 +196,7 @@ build_menu (struct boot_entry *boot_entries)
   char *submenu = NULL;
   const char *args[2] = { NULL, NULL };
   struct boot_entry *entry = boot_entries;
+  char *main_entry_src;
 
   if (!boot_entries[0].src)
     return;
@@ -205,8 +205,10 @@ build_menu (struct boot_entry *boot_entries)
    * [ Main entry ]
    */
 
+  main_entry_src = grub_xasprintf ("savedefault\n%s", boot_entries[0].src);
   args[0] = MAIN_ENTRY_TITLE;
-  grub_normal_add_menu_entry (1, args, NULL, NULL, "bls", NULL, NULL, boot_entries[0].src, 0);
+  grub_normal_add_menu_entry (1, args, NULL, NULL, "bls", NULL, NULL, main_entry_src, 0);
+  grub_free (main_entry_src);
 
   /*
    * [ Submenu ]


### PR DESCRIPTION
We are facing unfortunate behaviour with an old grub version that we
previously deployed, where attempts to boot the previously saved
boot entry result in the system being unable to boot into a new
version automatically.

Recent behaviour is better, but as a precaution, ensure that
the specific Endless versions on the boot menu do not even
have the "savedefault" command present. Even though we allow
the user to manually select an old version for diagnostic purposes,
we do not want to make that "stick"; we want the norm to be booting
the latest installed version.

https://phabricator.endlessm.com/T22114