### PR TITLE
tsc: Change default tsc calibration method to pmtimer on EFI systems

### DIFF
--- a/grub-core/kern/i386/tsc.c
+++ b/grub-core/kern/i386/tsc.c
@@ -68,7 +68,7 @@ grub_tsc_init (void)
 #ifdef GRUB_MACHINE_XEN
   (void) (grub_tsc_calibrate_from_xen () || calibrate_tsc_hardcode());
 #elif defined (GRUB_MACHINE_EFI)
-  (void) (grub_tsc_calibrate_from_pit () || grub_tsc_calibrate_from_pmtimer () || grub_tsc_calibrate_from_efi() || calibrate_tsc_hardcode());
+  (void) (grub_tsc_calibrate_from_pmtimer () || grub_tsc_calibrate_from_pit () || grub_tsc_calibrate_from_efi() || calibrate_tsc_hardcode());
 #elif defined (GRUB_MACHINE_COREBOOT)
   (void) (grub_tsc_calibrate_from_pmtimer () || grub_tsc_calibrate_from_pit () || calibrate_tsc_hardcode());
 #else


### PR DESCRIPTION
On efi systems, make pmtimer based tsc calibration the default over the
pit. This prevents Grub from hanging on Intel SoC systems that power gate
the pit.

Signed-off-by: David E. Box <david.e.box@linux.intel.com>
Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>

Origin: upstream, https://git.savannah.gnu.org/cgit/grub.git/commit/?id=446794de8da4329ea532cbee4ca877bcafd0e534
Bug-Debian: https://bugs.debian.org/883193
Last-Update: 2017-12-01

Patch-Name: tsc_efi_default_to_pmtimer.patch

Cherry-picked from https://salsa.debian.org/grub-team/grub/commit/edda6b09c43ecbd0f7735e0a78a5ea94ac5fda66.patch

https://phabricator.endlessm.com/T23172