### PR TITLE
Fix build after Debian Buster distro rebase.

### DIFF
--- a/grub-core/efiemu/i386/loadcore64.c
+++ b/grub-core/efiemu/i386/loadcore64.c
@@ -98,6 +98,7 @@ grub_arch_efiemu_relocate_symbols64 (grub_efiemu_segment_t segs,
 		    break;
 
 		  case R_X86_64_PC32:
+		  case R_X86_64_PLT32:
 		    err = grub_efiemu_write_value (addr,
 						   *addr32 + rel->r_addend
 						   + sym.off

--- a/grub-core/fs/btrfs.c
+++ b/grub-core/fs/btrfs.c
@@ -175,7 +175,7 @@ struct grub_btrfs_time
 {
   grub_int64_t sec;
   grub_uint32_t nanosec;
-} __attribute__ ((aligned (4)));
+} GRUB_PACKED;
 
 struct grub_btrfs_inode
 {

--- a/grub-core/kern/x86_64/dl.c
+++ b/grub-core/kern/x86_64/dl.c
@@ -70,6 +70,7 @@ grub_arch_dl_relocate_symbols (grub_dl_t mod, void *ehdr,
 	  break;
 
 	case R_X86_64_PC32:
+	case R_X86_64_PLT32:
 	  {
 	    grub_int64_t value;
 	    value = ((grub_int32_t) *addr32) + rel->r_addend + sym->st_value -

--- a/grub-core/script/yylex.l
+++ b/grub-core/script/yylex.l
@@ -91,7 +91,7 @@ typedef size_t yy_size_t;
 #define stdin  0
 #define stdout 0
 
-#define fprintf(...) 0
+#define fprintf(...) (void)0
 #define exit(...) grub_fatal("fatal error in lexer")
 #endif
 

--- a/include/grub/efiemu/runtime.h
+++ b/include/grub/efiemu/runtime.h
@@ -29,7 +29,7 @@ struct grub_efiemu_ptv_rel
 
 struct efi_variable
 {
-  grub_efi_guid_t guid;
+  grub_efi_packed_guid_t guid;
   grub_uint32_t namelen;
   grub_uint32_t size;
   grub_efi_uint32_t attributes;

--- a/include/grub/partition.h
+++ b/include/grub/partition.h
@@ -66,7 +66,7 @@ struct grub_gpt_part_type
   grub_uint16_t data2;
   grub_uint16_t data3;
   grub_uint8_t data4[8];
-} __attribute__ ((aligned(8)));
+} GRUB_PACKED;
 typedef struct grub_gpt_part_type grub_gpt_part_type_t;
 
 /* Partition description.  */

--- a/tests/uhci_test.in
+++ b/tests/uhci_test.in
@@ -41,7 +41,7 @@ echo "hello" > "$outfile"
 
 tar cf "$imgfile" "$outfile"
 
-if [ "$(echo "nativedisk; source '(usb0)/$outfile';" | "${grubshell}" --qemu-opts="-usb -usbdevice disk:$imgfile" | tail -n 1)" != "Hello World" ]; then
+if [ "$(echo "nativedisk; source '(usb0)/$outfile';" | "${grubshell}" --qemu-opts="-device ich9-usb-uhci1 -drive id=my_usb_disk,file=$imgfile,if=none -device usb-storage,drive=my_usb_disk" | tail -n 1)" != "Hello World" ]; then
    rm "$imgfile"
    rm "$outfile"
    exit 1

--- a/tests/util/grub-shell.in
+++ b/tests/util/grub-shell.in
@@ -369,6 +369,13 @@ test -z "$debug" || echo "GRUB ROM directory: ${rom_directory}" >&2
 
 if test -z "$debug"; then
   qemuopts="${qemuopts} -nographic -monitor file:/dev/null"
+  # SeaBIOS 1.11.0 added support for VGA emulation over a serial port.  If
+  # this is configured in SeaBIOS, then -nographic causes some extra junk to
+  # end up on the serial console, which interferes with our tests.  This
+  # workaround unfortunately causes qemu to issue a warning 'externally
+  # provided fw_cfg item names should be prefixed with "opt/"', but there
+  # doesn't seem to be a better option.
+  qemuopts="${qemuopts} -fw_cfg name=etc/sercon-port,string=0"
 fi
 
 if [ x$boot != xnet ] && [ x$boot != xemu ]; then

--- a/util/grub-mkimagexx.c
+++ b/util/grub-mkimagexx.c
@@ -832,6 +832,7 @@ SUFFIX (relocate_addresses) (Elf_Ehdr *e, Elf_Shdr *sections,
 		  break;
 
 		case R_X86_64_PC32:
+		case R_X86_64_PLT32:
 		  {
 		    grub_uint32_t *t32 = (grub_uint32_t *) target;
 		    *t32 = grub_host_to_target64 (grub_target_to_host32 (*t32)

--- a/util/grub-module-verifier.c
+++ b/util/grub-module-verifier.c
@@ -19,6 +19,7 @@ struct grub_module_verifier_arch archs[] = {
       -1
     }, (int[]){
       R_X86_64_PC32,
+      R_X86_64_PLT32,
       -1
     }
   },


### PR DESCRIPTION
The rebased of our distro on Debian Buster broke the grub build. Luckily the failures were all already sorted upstream, so this PR is a backport of a few upstream patches that address them.

https://phabricator.endlessm.com/T26580