### PR TITLE
[ENDLESS] break verifiers to stop boot failures READ LOG WHEN REBASING

### DIFF
--- a/grub-core/kern/main.c
+++ b/grub-core/kern/main.c
@@ -308,9 +308,22 @@ grub_main (void)
   grub_setcolorstate (GRUB_TERM_COLOR_STANDARD);
 #endif
 
+#if 0
+  /* [ENDLESS] - TEMPORARY FIX until debian moves to the lockdown verifier
+   * and shim_lock verifier in the verifiers infrastructure for secure boot
+   * validation.
+   *
+   * At the time of this writing, those things are handled differently
+   * in upstream grub and debian packaging, but some of the upstream pieces
+   * are present due to cherry picking of security fixes.
+   *
+   * Once debian moves to upstream's methods this change *MUST* be dropped,
+   * or secure boot will fail to work.
+   */
+
   /* Init verifiers API. */
   grub_verifiers_init ();
-
+#endif
   grub_load_config ();
 
   grub_boot_time ("Before loading embedded modules.");


### PR DESCRIPTION
WARNING FOR REBASER: This patch *MUST* be dropped when Debian drops their
downstream lockdown and secure boot/shim validation patches!!!

This disables the verifier infrastructure, which is currently the upstream
way to do secure boot verification of kernel images, as well as the way
upstream prevents loading of unsigned modules when secure boot is active.

Debian currently has their own patches that do these things, so we're
stuck with those. With debian's patches at time of this writing, the
shim_lock verifier is intentionally broken, so the verifier framework will
deny booting anything while secure boot is active.

We disable verifiers, and Debian's lockdown and shim_lock machinery works.

At some point in the future (grub 2.06?) Debian will likely move to the
upstream validation methods, at which point this patch will be breaking
secure boot validation and allow booting unsigned kernels while secure boot
is on.

This can not be allowed to happen, so anyone rebasing this patch must take
care to ensure it is still valid!

https://phabricator.endlessm.com/T31671