### PR TITLE
fixup! SBAT: Add endless SBAT

### DIFF
--- a/debian/sbat.endless.csv.in
+++ b/debian/sbat.endless.csv.in
@@ -1,4 +1,4 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,1,Free Software Foundation,grub,@UPSTREAM_VERSION@,https://www.gnu.org/software/grub/
+grub,1,Free Software Foundation,grub,2.04,https://www.gnu.org/software/grub/
 grub.debian,1,Debian,grub2,2.04-16,https://tracker.debian.org/pkg/grub2
 grub.endless,1,Endless OS Foundation LLC,grub2,@DEB_VERSION@,https://github.com/endlessm/grub


### PR DESCRIPTION
Fix package versions in our SBAT file

Because we have Jenkins generate the package for us, @UPSTREAM_VERSION@
is not quite the actual version for GRUB upstream, but the portion of
the version string corresponding to the main code branch
(2.04+dev245.7421863), so we should instead spell-out the real upstream
version (2.04).

For our own downstream version, we should use @UPSTREAM_VERSION@ instead
of @DEB_VERSION@, so we leave out the packaging version and build
counter, as we do for shim's SBAT section.

https://phabricator.endlessm.com/T31888