### PR TITLE
Include SBAT data in standalone EFI images

### DIFF
--- a/debian/build-sa-efi-images
+++ b/debian/build-sa-efi-images
@@ -1,8 +1,8 @@
 #! /bin/sh
 set -e
 
-if [ $# -lt 6 ]; then
-	echo "usage: $0 GRUB-MKSTANDALONE GRUB-CORE OUTPUT-DIRECTORY PLATFORM EFI-NAME CONF-NAME"
+if [ $# -lt 7 ]; then
+	echo "usage: $0 GRUB-MKSTANDALONE GRUB-CORE OUTPUT-DIRECTORY PLATFORM EFI-NAME CONF-NAME SBAT-CSV"
 	exit 1
 fi
 
@@ -12,6 +12,7 @@ outdir="$3"
 platform="$4"
 efi_name="$5"
 conf_name="$6"
+sbat_csv="$7"
 
 workdir=
 
@@ -49,6 +50,6 @@ modules="$modules sleep test time true video file squash4 ls"
 
 ( cd "$workdir/memdisk" && "$grub_mkstandalone" --modules="$modules" \
 	-d "$grub_core" -O "$platform" -o "$outdir/$efi_name.efi" \
-	$(find -type f))
+	--sbat="$sbat_csv" $(find -type f))
 
 exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -341,11 +341,18 @@ platform_subst = \
 	fi
 
 install/grub-efi-amd64-image:
+	grub_dir=`mktemp -d` ; \
+	sed -e "s/@DEB_VERSION@/$(deb_version)/g" \
+		-e "s/@UPSTREAM_VERSION@/$(upstream_version)/g" \
+		<debian/sbat.$(SB_EFI_VENDOR).csv.in \
+		>$${grub_dir}/sbat.$(SB_EFI_VENDOR).csv; \
 	$(CURDIR)/debian/build-sa-efi-images \
 		obj/grub-efi-amd64/grub-mkstandalone \
 		obj/grub-efi-amd64/grub-core \
 		debian/tmp-$(package)/images/x86_64-efi/ \
-		x86_64-efi grubx64 $(CURDIR)/debian/conf/grub_embedded_image.cfg
+		x86_64-efi grubx64 \
+		$(CURDIR)/debian/conf/grub_embedded_image.cfg \
+		$${grub_dir}/sbat.$(SB_EFI_VENDOR).csv
 	set -e ; for i in $(AUTOGEN_DEB_FILES) ; do \
 		if [ -e debian/$(package).$$i.in ] ; then \
 			cat debian/$(package).$$i.in \
@@ -354,11 +361,18 @@ install/grub-efi-amd64-image:
 	done
 
 install/grub-efi-ia32-image:
+	grub_dir=`mktemp -d` ; \
+	sed -e "s/@DEB_VERSION@/$(deb_version)/g" \
+		-e "s/@UPSTREAM_VERSION@/$(upstream_version)/g" \
+		<debian/sbat.$(SB_EFI_VENDOR).csv.in \
+		>$${grub_dir}/sbat.$(SB_EFI_VENDOR).csv; \
 	$(CURDIR)/debian/build-sa-efi-images \
 		obj/grub-efi-ia32/grub-mkstandalone \
 		obj/grub-efi-ia32/grub-core \
 		debian/tmp-$(package)/images/i386-efi/ \
-		i386-efi bootia32 $(CURDIR)/debian/conf/grub_embedded_image.cfg
+		i386-efi bootia32 \
+		$(CURDIR)/debian/conf/grub_embedded_image.cfg \
+		$${grub_dir}/sbat.$(SB_EFI_VENDOR).csv
 	set -e ; for i in $(AUTOGEN_DEB_FILES) ; do \
 		if [ -e debian/$(package).$$i.in ] ; then \
 			cat debian/$(package).$$i.in \


### PR DESCRIPTION
The grub EFI image we actually put in the ESP is built with our own
`build-sa-efi-images` script, not the `build-efi-images` script provided
by debian. While debian's script was updated to include the SBAT data in
the images, ours was not.

Update `build-sa-efi-images` to require an SBAT CSV file argument and
pass it in the `--sbat` option to `grub-mkstandalone`. The CSV
templating is not pretty but was copied from the `build-efi-images`
recipe for consistency.

https://phabricator.endlessm.com/T32500